### PR TITLE
Fix/loose nodes

### DIFF
--- a/NASB_Parser_To_xNode/Program.cs
+++ b/NASB_Parser_To_xNode/Program.cs
@@ -23,11 +23,17 @@ namespace NASB_Parser_To_xNode
         {
             foreach (NASBParserFile nasbParserFile in nasbParserFiles)
             {
+                if (Consts.classesToIgnore.Contains(nasbParserFile.className)) continue;
+                if (Consts.enumOnlyFiles.Contains(nasbParserFile.className)) continue;
+
                 string fileText = xNodeTextGenerator.GenerateXNodeFileText(nasbParserFile, false);
                 xNodeFileGenerator.GenerateXNodeFile(fileText, outputPath, nasbParserFile.relativePath);
 
                 foreach (NASBParserFile nestedFile in nasbParserFile.nestedClasses)
                 {
+                    if (Consts.classesToIgnore.Contains(nestedFile.className)) continue;
+                    if (Consts.enumOnlyFiles.Contains(nasbParserFile.className)) continue;
+
                     fileText = xNodeTextGenerator.GenerateXNodeFileText(nestedFile, true);
                     xNodeFileGenerator.GenerateXNodeFile(fileText, outputPath, nestedFile.relativePath);
                 }

--- a/NASB_Parser_To_xNode/Utils/Consts.cs
+++ b/NASB_Parser_To_xNode/Utils/Consts.cs
@@ -58,6 +58,8 @@ namespace NASB_Parser_To_xNode
 
         public static List<string> enumOnlyFiles = new List<string> { "GIEV", "HurtType", "Ease" };
 
+        public static List<string> classesToIgnore = new List<string> { "BitUtil" };
+
         public static Dictionary<string, string> classesToNamespaces = new Dictionary<string, string> {
             {"FloatSource", "FloatSources"},
             {"Jump", "Jumps"},

--- a/NASB_Parser_To_xNode/xNodeFileGenerator/xNodeTextGenerator.cs
+++ b/NASB_Parser_To_xNode/xNodeFileGenerator/xNodeTextGenerator.cs
@@ -119,6 +119,14 @@ namespace NASB_Parser_To_xNode
                 nasbParserFile.parentClass = Consts.classesToNamespaces.First(x => x.Value.Equals(parentFolder)).Key;
                 nasbParserFile.className = nasbParserFile.relativePath.Replace(".", "_");
                 nasbParserFile.className = nasbParserFile.className.Substring(nasbParserFile.className.LastIndexOf("\\") + 1);
+            } else if (
+                nasbParserFile.relativePath.Contains("\\") 
+                && nasbParserFile.parentClass.Equals("ISerializable")
+                && !Consts.classesToNamespaces.ContainsKey(nasbParserFile.className))
+            {
+                // Set parent class for loose files in folders
+                var parentFolder = nasbParserFile.relativePath.Substring(0, nasbParserFile.relativePath.LastIndexOf("\\"));
+                nasbParserFile.parentClass = Consts.classesToNamespaces.First(x => x.Value.Equals(parentFolder)).Key;
             }
 
             string classDeclaration = $"public {(nasbParserFile.isAbstract ? "abstract " : "")}class {nasbParserFile.className}";

--- a/NASB_Parser_To_xNode/xNodeFileGenerator/xNodeTextGenerator.cs
+++ b/NASB_Parser_To_xNode/xNodeFileGenerator/xNodeTextGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -115,6 +115,8 @@ namespace NASB_Parser_To_xNode
 
             if (isNested)
             {
+                var parentFolder = nasbParserFile.relativePath.Substring(0, nasbParserFile.relativePath.LastIndexOf("\\"));
+                nasbParserFile.parentClass = Consts.classesToNamespaces.First(x => x.Value.Equals(parentFolder)).Key;
                 nasbParserFile.className = nasbParserFile.relativePath.Replace(".", "_");
                 nasbParserFile.className = nasbParserFile.className.Substring(nasbParserFile.className.LastIndexOf("\\") + 1);
             }
@@ -148,6 +150,11 @@ namespace NASB_Parser_To_xNode
                     }
 
                     AddToFileContents(VariableStringGenerator.GetVariableString(variableObj, nasbParserFile, isNested));
+                }
+
+                if (nasbParserFile.className.Contains("MessageDynamicNode"))
+                {
+                    Console.WriteLine("testing");
                 }
 
                 // Node specific functions

--- a/NASB_Parser_To_xNode/xNodeFileGenerator/xNodeTextGenerator.cs
+++ b/NASB_Parser_To_xNode/xNodeFileGenerator/xNodeTextGenerator.cs
@@ -160,11 +160,6 @@ namespace NASB_Parser_To_xNode
                     AddToFileContents(VariableStringGenerator.GetVariableString(variableObj, nasbParserFile, isNested));
                 }
 
-                if (nasbParserFile.className.Contains("MessageDynamicNode"))
-                {
-                    Console.WriteLine("testing");
-                }
-
                 // Node specific functions
                 if (nasbParserFile.parentClass != null)
                 {


### PR DESCRIPTION
- Fix parent class for loose file
- Ignore enum only classes when generating class files
- Add list of extra classes to ignore when generating class files. Currently only ignoring "BitUtil"